### PR TITLE
Rabbit connectivity

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,3 +59,12 @@ services:
       - ENDPOINT=s3server
       - BUCKET=aws-ingest
     image: scality/s3server:latest
+
+  rabbitmq:
+    image: rabbitmq:3
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    environment:
+      - RABBITMQ_DEFAULT_USER=user
+      - RABBITMQ_DEFAULT_PASS=password

--- a/datatransfer/settings.py
+++ b/datatransfer/settings.py
@@ -44,6 +44,19 @@ READ_REDIS_HOST = os.environ.get('READ_REDIS_HOST', 'localhost')
 READ_REDIS_PORT = os.environ.get('READ_REDIS_PORT', '6379')
 READ_REDIS_PASSWORD = os.environ.get('READ_REDIS_PASSWORD', None)
 
+READ_MQ_HOST = os.environ.get('READ_MQ_HOST', 'localhost')
+READ_MQ_PORT = os.environ.get('READ_MQ_PORT', '5672')
+READ_MQ_PATH = os.environ.get('READ_MQ_PATH', 'a_path')
+READ_MQ_USERNAME = os.environ.get('READ_MQ_USERNAME', None)
+READ_MQ_PASSWORD = os.environ.get('READ_MQ_PASSWORD', None)
+
+WRITE_MQ_HOST = os.environ.get('WRITE_MQ_HOST', 'localhost')
+WRITE_MQ_PORT = os.environ.get('WRITE_MQ_PORT', '5672')
+WRITE_MQ_PATH = os.environ.get('WRITE_MQ_PATH', 'a_path')
+WRITE_MQ_USERNAME = os.environ.get('WRITE_MQ_USERNAME', None)
+WRITE_MQ_PASSWORD = os.environ.get('WRITE_MQ_PASSWORD', None)
+
+
 WRITE_REDIS_HOST = os.environ.get('WRITE_REDIS_HOST', 'localhost')
 WRITE_REDIS_PORT = os.environ.get('WRITE_REDIS_PORT', '6379')
 WRITE_REDIS_PASSWORD = os.environ.get('WRITE_REDIS_PASSWORD', None)

--- a/datatransfer/storage.py
+++ b/datatransfer/storage.py
@@ -784,5 +784,10 @@ class MessageQueue:
 
     def channel(self):
         """Getter for _channel
+
+        Returns
+        -------
+        obj:
+            Pika connection channel object for queue interaction 
         """
         return self._channel

--- a/datatransfer/storage.py
+++ b/datatransfer/storage.py
@@ -786,15 +786,3 @@ class MessageQueue:
         """Getter for _channel
         """
         return self._channel
-
-    def publish_event(self, event):
-        """
-        Publish event to queue
-        """
-        pass
-
-    def consume(self, callback):
-        """
-        Consume queue and apply callback to events
-        """
-        pass

--- a/datatransfer/storage.py
+++ b/datatransfer/storage.py
@@ -756,3 +756,46 @@ class RedisStorage:
 
     def exit(self):
         LOGGER.debug('Redis - Exit function')
+
+
+class MessageQueue:
+    """Abstraction for MQ interaction. 
+    MessageQueue will allow for the publishing and consumption of event from a queue.
+    Currently MessageQueue only supports RabbitMQ
+
+    Parameters
+    ----------
+    conf: dict of 'str' : 'str'
+        Provides connection details for the message queue.
+    """
+    def __init__(self, conf):
+        """
+        conf: host, port, queue_name
+        """
+        LOGGER.debug('MessageQueue - Creating MessageQueue instance')
+        try:
+            credentials = pika.PlainCredentials('user', 'pass')
+            connection = pika.BlockingConnection(pika.ConnectionParameters(host=conf.get('host'), 
+                                                                           port=int(conf.get('port')
+                                                                           credentials=credentials))
+            self.channel = connection.channel()
+            LOGGER.debug('MessageQueue - Connection established')
+            channel.queue_declare(queue=conf.get('queue_name'))
+	except Exception as err:
+	    LOGGER.exception('MessageQueue - Unexpected error ' + repr(err))
+	    raise
+	    	
+
+    def publish_event(self, event):
+        """
+        Publish event to queue
+        """
+        pass
+
+    def consume(self, callback):
+        """
+        Consume queue and apply callback to events
+        """
+        pass
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
     image: rabbitmq:3
     ports:
       - "5672:5672"
+      - "15672:15672"
     environment:
       - RABBITMQ_DEFAULT_USER=user
       - RABBITMQ_DEFAULT_PASS=password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,16 @@ services:
     depends_on:
       - s3server
     command: --endpoint-url=http://s3server:8000 s3 mb s3://aws-ingest
+
+  rabbitmq:
+    image: rabbitmq:3
+    ports:
+      - "5672:5672"
+    environment:
+      - RABBITMQ_DEFAULT_USER=user
+      - RABBITMQ_DEFAULT_PASS=password
+
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ boto3==1.4.8
 schedule==0.5.0
 paramiko==2.4.0
 redis==2.10.6
+pika==0.12.0

--- a/tests/test_message_queue.py
+++ b/tests/test_message_queue.py
@@ -1,0 +1,16 @@
+import unittest
+from datatransfer.storage import MessageQueue
+from unittest.mock import MagicMock
+
+class TestMessageQueue(unittest.TestCase):
+    def test_connection_establish(self):
+        conf = {'username': 'user',
+                'password': 'password',
+                'host': 'rabbitmq',
+                'port': '5672',
+                'queue_name': 'a_test_queue'}
+        mq = MessageQueue(conf)
+        self.assertIsNotNone(mq.channel())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Created and tested MessageQueue class which currently only handles RabbitMQ connectivity. 
- Added rabbitmq server to drone file for automated testing
- Added rabbitmq (and redis) containers to docker-compose file for local testing
- Added pika to requirements.txt 
- Added settings to settings file for MessageQueue config.

Currently MessageQueue only establishes a connection, future tickets cover event generation / publication and event consumption. 
